### PR TITLE
設定画面のロゴの縮小比率を是正する

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -21,6 +21,7 @@
       display: block;
       margin: 40px auto;
       width: 220px;
+      height: auto;
     }
 
     ul {


### PR DESCRIPTION
ユーザー設定画面の左上に見えるアイマストドンのロゴ `logo.png` が、縦横比率を維持せず誤った縮小がされていましたので、これを修正します。テストサーバーにインストール済です。