### PR TITLE
設定画面の左上のロゴが誤った比率で縮小されていたので修正

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -23,7 +23,7 @@ $no-columns-breakpoint: 600px;
       display: block;
       margin: 40px auto;
       width: 220px;
-      height: 100px;
+      height: auto;
     }
 
     @media screen and (max-width: $no-columns-breakpoint) {


### PR DESCRIPTION
ユーザー設定画面の左上に見えるアイマストドンのロゴ `logo.png` が、縦横比率を維持せず誤った縮小がされていましたので、これを修正します。テストサーバーにインストール済です。

ちゃんとブランチ切る位置を正しくしました。