### PR TITLE
メールに表示するロゴを Mastodon 標準のものに設定

### DIFF
--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -24,7 +24,7 @@
                               %tr
                                 %td.column-cell
                                   = link_to root_url do
-                                    = image_tag full_pack_url('media/images/mailer/logo.png'), alt: 'iMastodon', height: 34, class: 'logo'
+                                    = image_tag full_pack_url('media/images/mailer/logo_full.png'), alt: 'iMastodon', height: 34, class: 'logo'
 
     = yield
 


### PR DESCRIPTION
メールに表示するロゴを imastodon.blue のものではなく Mastodon 標準のものに変更しました。
Webpack さんは Mastodon 標準のものをプレコンパイルしており、必要なファイルもすでに存在しています。
根本対策としては、Webpack のコンフィグファイルみたいなものをいじって、Webpack プレコンパイル時に imastodon.blue のロゴをパックしてもらうように設定変更しないといけないと思います。

fixes #45 