### PR TITLE
ハッシュタグカラムに含めることができる追加のハッシュタグの数を40個に変更（以前はノーリミット）

### DIFF
--- a/app/services/hashtag_query_service.rb
+++ b/app/services/hashtag_query_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class HashtagQueryService < BaseService
-  LIMIT_PER_MODE = 4
+  LIMIT_PER_MODE = 40
 
   def call(tag, params, account = nil, local = false)
     tags = tags_for(Array(tag.name) | Array(params[:any])).pluck(:id)


### PR DESCRIPTION
ハッシュタグカラムに含めることができる「追加のハッシュタグ」の数を、そのカラムのハッシュタグ自身を含めて合計 40 個に変更します。

v2.9.x までは最大数の制限なしで追加できました。v3.0.0 で最大数が 4 個に制限されました。
アイマス関連のハッシュタグを 1 カラムで追いかけているユーザーなどは、このカラムに十数個のハッシュタグを追加している場合もあるでしょうから、この制限を緩和することをおすすめします。

ちなみに僕の個人サーバーでも同様の変更を入れています。